### PR TITLE
PDO::quote() does not accept an array as parameter.

### DIFF
--- a/classes/Course/class.hubCourse.php
+++ b/classes/Course/class.hubCourse.php
@@ -567,13 +567,13 @@ class hubCourse extends hubRepositoryObject {
 	 */
 	protected $title_extension = '';
 	/**
-	 * @var array
+	 * @var string
 	 *
 	 * @db_has_field        true
 	 * @db_fieldtype        text
 	 * @db_length           256
 	 */
-	protected $administrators = array();
+	protected $administrators = '';
 	/**
 	 * @var string
 	 *


### PR DESCRIPTION
PDO::quote() wrapper requires a string. Courses can now again be included through the HUB plugin.