### PR TITLE
Fix important information parameter in course information page

### DIFF
--- a/classes/Course/class.hubCourse.php
+++ b/classes/Course/class.hubCourse.php
@@ -190,6 +190,10 @@ class hubCourse extends hubRepositoryObject {
 			$this->ilias_object->setActivationType(IL_CRS_ACTIVATION_UNLIMITED);
 			$update = true;
 		}
+        if($this->getImportantInformation() !== $this->ilias_object->getImportantInformation()) {
+            $this->ilias_object->setImportantInformation($this->getImportantInformation());
+            $update = true;
+        }
 		if ($update) {
 			$this->ilias_object->setOwner($this->getOwner());
 			$this->ilias_object->update();

--- a/classes/Course/class.hubCourse.php
+++ b/classes/Course/class.hubCourse.php
@@ -116,9 +116,9 @@ class hubCourse extends hubRepositoryObject {
 		$this->ilias_object->setTitle($this->getTitlePrefix() . $this->getTitle() . $this->getTitleExtension());
 		$this->ilias_object->setDescription($this->getDescription());
 		$this->ilias_object->setImportId($this->returnImportId());
-		$this->ilias_object->setImportantInformation($this->getImportantInformation());
 		$this->updateAdditionalFields();
 		$this->ilias_object->create();
+        $this->ilias_object->setImportantInformation($this->getImportantInformation());
 		$this->ilias_object->createReference();
 		$node = $this->getDependecesNode();
 		$this->ilias_object->putInTree($node);


### PR DESCRIPTION
The field "important information" was overwritten by default values and never updated in the DB (crs_settings). Now the value is set correctly and updated if changed.